### PR TITLE
MacOS support possibilitiy

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ features of `archivemount`. You can also view mounpoints in your system based on
 
 > [!Note]
 >
-> Currently Linux only. MacOS usage will be added.
+> Currently, it works on Linux. Help wanted for MacOS!
 
 1. [archivemount](https://github.com/cybernoid/archivemount)
 
@@ -60,6 +60,16 @@ can be added, feel free to add it in your `init.lua` and make an issue/PR regard
 
 Yazi is an amazing, blazing fast terminal file manager, with a variety of plugins, flavors and themes. Check them out at [awesome-yazi](https://github.com/AnirudhG07/awesome-yazi) and the official [yazi webpage](https://yazi-rs.github.io/).
 
-## TODO
+## MacOS
+> [!Important]
+>
+> This is not tested by me. Only an inspiration by people.
+> For any users, please test and provide feedback for the same.
 
-1. Application on MacOS which uses MacFuse for archivemounting.
+You can install `archivemount` on MacOS through `macports`, it available on Homebrew only on Linux(linuxbrew) -
+```
+sudo port install archivemount
+```
+
+Application on MacOS which uses MacFuse for archivemounting. You would need to enable MacFuse for this. The syntax provided by archivemount is same as that of linux, so the plugin should work.
+


### PR DESCRIPTION
This PR doesn't confirm the support for MacOS. But provide basic details on how one can configure archive mount on MacOS. 
Help wanted: Please install archive mount, enable MacFuse and share feedback on how well the plugin works for MacOS. Thanks!

Note: You can use other mounting command line tools if not comfortable with archivemount on MacOS. But since this repo is meant for `archivemount`, so yeah...

